### PR TITLE
Improve jenkins image with parallel building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
+logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ ARG DOCKER_VERSION=1.10.3
 
 ARG JENKINS_VERSION=1.642
 
-ARG JENKINS_INSTALL_INITS_URL=https://github.com/forj-oss/jenkins-install-inits/raw/master
-
 # Jenkins is ran with user `jenkins`, uid = 1000
 # If you bind mount a volume from host/volume from a data container,
 # ensure you use same uid
@@ -41,6 +39,7 @@ COPY ref/jenkins.start.d/README.md $JENKINS_DATA_REF/jenkins.start.d/
 RUN chown -R jenkins $JENKINS_HOME $JENKINS_DATA_REF
 
 COPY jenkins.sh /usr/local/bin/
+ARG JENKINS_INSTALL_INITS_URL=https://github.com/forj-oss/jenkins-install-inits/raw/master
 ADD $JENKINS_INSTALL_INITS_URL/jenkins-install.sh /usr/local/bin/
 RUN chmod +rx /usr/local/bin/jenkins-install.sh
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We introduced several new features, like:
 Usually, you won't do that, because you want to build your own jenkins with the list of features you need. But if you want to see a basic version of jenkins, you can do the following:
 
 ```bash
-docker run -it --rm -p 8080:8080 forjdevops/jenkins-dood:1.654
+docker run -it --rm -p 8080:8080 forjdevops/jenkins-dood:latest_1.658
 ```
 
 ## Jenkins version and docker tags
@@ -25,25 +25,30 @@ A docker image is versionned through his tag version and then pushed. Then on yo
 Ex:
 
 ```Dockerfile
-FROM forjdevops/jenkins-dood:1.642
+FROM forjdevops/jenkins-dood:latest_1.642
 ```
 
-We deliver several different jenkins version and maintain some of them. For docker image tagging, we follow those rules:
-- A new version of jenkins gets tag like the jenkins version prefixed by the project release ie `<ReleaseVersion>_<JenkinsVersion>`.
+We deliver several different jenkins version and maintain some of them.
+For docker image tagging, we follow those rules:
+- Some version of jenkins (3 versions) gets a tag prefixed by
+  the project release ie `<ReleaseVersion>_<JenkinsVersion>`.
 
-  Ex: `0.2_1.654`
-- A branch of version. We push 2 different branches: 1.6x and 2.x. Latest version version of a branch gets named as `<ReleaseVersion>_<BranchVersion>_latest`.
+  Ex: `0.2_1.658`, `0.2_1.642`, `0.2_2.50`
 
-  Ex: `0.2_2.x_latest`
+- A branch of version. We maintain 3 different branches: 1.6x-latest, 1.6x-stable and 2.x.
+  Latest version of a branch gets named as `<ReleaseVersion>_<BranchVersion>-latest`.
+
+  Ex: `0.2_2.x-latest`
+
 - `<ReleaseVersion>_latest` will refer to the latest version for a dedicated version of this project.
 
-  ex: `0.2_latest`
+  Ex: `0.2_latest`
 
-- `latest_<jenkins_version|latest>` will refer to the HEAD of the `jenkins-ci` repository. It will be updated any time a PR is merged.
+- `latest_<jenkins_version|latest>` will refer to the HEAD of the `jenkins-ci` repository. It will be updated any time a PR on jenkins-ci is merged.
 
 - latest is the default tag for docker. We use it to refer to the latest version of jenkins, as found in http://pkg.jenkins.io/redhat/
 
-  Ex: `latest` refer to the latest version of jenkins and version of this project.
+  Ex: `latest` refer to the latest version of jenkins and version of this project ie is identical to `latest_latest`
 
 
 To get a list of published and available versions, connect to [Docker Registry](https://hub.dockercom/forjdevops/jenkins-dood/tags)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -47,7 +47,12 @@ else
    PUSH=true
 fi
 
+if [ "$DOCKER_CMD" = "" ]
+then
+   DOCKER_CMD="sudo docker"
+fi
+
 echo "-------------------------"
 set -x
-[ $PUSH = true ] && sudo docker pull $TAG_NAME || echo "Building it from scratch"
-sudo docker build $PROXY $TAG_ARG $JENKINS_VERSION_ARG $DOCKER_VERSION_ARG $JENKINS_INSTALL_URL_FLAG .
+[ $PUSH = true ] && $DOCKER_CMD pull $TAG_NAME || echo "Building it from scratch"
+$DOCKER_CMD build $PROXY $TAG_ARG $JENKINS_VERSION_ARG $DOCKER_VERSION_ARG $JENKINS_INSTALL_URL_FLAG .

--- a/bin/do_build-tag.sh
+++ b/bin/do_build-tag.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if [  "$1" = "--dry-run" ]
+then
+    export DOCKER_CMD="echo docker"
+    echo "Dry run"
+    shift
+else
+    export DOCKER_CMD="sudo docker"
+fi
+
+export JENKINS_VERSION="$(echo "$1" | awk -F'|' '{ print $1 }')"
+TAGS="$(echo "$1" | awk -F'|' '{ print $2 }' | sed 's/,/ /g')"
+echo "=============== Building jenkins-dood flavor Jenkins $JENKINS_VERSION"
+$(dirname $0)/build.sh $TAG_BASE:${VERSION}_$JENKINS_VERSION
+echo "=============== Publishing flavored tags: $TAGS"
+for TAG in $TAGS
+do
+  echo "=> $TAG_BASE:${VERSION}_$TAG"
+  $DOCKER_CMD tag $TAG_BASE:${VERSION}_$JENKINS_VERSION $TAG_BASE:${VERSION}_$TAG
+  $DOCKER_CMD push $TAG_BASE:${VERSION}_$TAG
+done
+echo "=============== DONE - Flavor Jenkins $JENKINS_VERSION"
+if [ "$JENKINS_VERSION" = "$(cat releases.lst | tail -n 1 | awk -F'|' '{ print $1 }')" ]
+then
+   echo "=============== Publishing latest tags with Default Flavor $JENKINS_VERSION embedded."
+   if [ $VERSION != latest ]
+   then
+        echo "=> $TAG_BASE:$VERSION"
+        set -x
+        $DOCKER_CMD push $TAG_BASE:$VERSION
+        set +x
+   fi
+   echo "=> $TAG_BASE:latest ($TAG_BASE:${VERSION}_$JENKINS_VERSION)"
+   set -x
+   $DOCKER_CMD tag $TAG_BASE:${VERSION}_$JENKINS_VERSION $TAG_BASE:latest
+   $DOCKER_CMD push $TAG_BASE:latest
+   set +x
+   echo "=============== DONE"
+fi
+rm -f logs/$JENKINS_VERSION.run

--- a/bin/publish-alltags.sh
+++ b/bin/publish-alltags.sh
@@ -13,7 +13,7 @@
 # Then this job should implement the following code in jenkins
 # And jenkins-ci images for each flavors will be officially pushed to the internal registry.
 
-TAG_BASE="forjdevops/jenkins-dood"
+export TAG_BASE="forjdevops/jenkins-dood"
 
 if [ ! -f VERSION ] || [ ! -f releases.lst ]
 then
@@ -21,9 +21,17 @@ then
    exit 1
 fi
 
+if [ "$1" = "--dry-run" ]
+then
+    DRY_RUN="--dry-run"
+    shift
+else
+    DRY_RUN=""
+fi
+
 case "$1" in
   release-it )
-    VERSION=$(cat VERSION)
+    export VERSION=$(cat VERSION)
     if [ "$(git tag -l $VERSION)" = "" ]
     then
        echo "Unable to publish a release version. git tag missing"
@@ -35,11 +43,11 @@ case "$1" in
        echo "'$COMMIT' is not tagged with '$VERSION'. Only commit tagged can publish officially this tag as docker image."
        exit 1
     fi
-    VERSION_TAG=${VERSION}_
+    export VERSION_TAG=${VERSION}_
     ;;
   latest )
-    VERSION=latest
-    VERSION_TAG=latest_
+    export VERSION=latest
+    export VERSION_TAG=latest_
     ;;
   *)
     echo "Script used to publish release and latest code ONLY. If you want to test a fork, use build. It will create a local docker image jenkins-dood:test"
@@ -49,24 +57,32 @@ esac
 cat releases.lst | while read LINE
 do
    [[ "$LINE" =~ ^# ]] && continue
-   export JENKINS_VERSION="$(echo "$LINE" | awk -F'|' '{ print $1 }')"
-   TAGS="$(echo "$LINE" | awk -F'|' '{ print $2 }' | sed 's/,/ /g')"
-   echo "=============== Building jenkins-dood flavor Jenkins $JENKINS_VERSION"
-   $(dirname $0)/build.sh $TAG_BASE:${VERSION}_$JENKINS_VERSION
-   echo "=============== Publishing flavored tags"
-   for TAG in $TAGS
-   do
-      echo "=> $TAG_BASE:${VERSION}_$TAG"
-      sudo docker tag $TAG_BASE:${VERSION}_$JENKINS_VERSION $TAG_BASE:${VERSION}_$TAG
-      sudo docker push $TAG_BASE:${VERSION}_$TAG
-   done
-   echo "=============== DONE - Flavor Jenkins $JENKINS_VERSION"
+
+   if [ "$DRY_RUN"  = "--dry-run" ]
+   then
+       bin/do_build-tag.sh $DRY_RUN "$LINE"
+   else
+       APP_VERSION=$(echo "$LINE" | awk -F'|' '{ print $1 }')
+       LOG=logs/$APP_VERSION.log
+       echo "LOG: $LOG"
+       mkdir -p logs
+       touch logs/$APP_VERSION.run
+       nohup bin/do_build-tag.sh $DRY_RUN "$LINE" > $LOG 2>&1 &
+       sleep 2
+   fi
 done
-export JENKINS_VERSION="$(cat releases.lst | tail -n 1 | awk -F'|' '{ print $1 }')"
-echo "=============== Publishing latest tags with Default Flavor $JENKINS_VERSION embedded.
-=> $TAG_BASE:$VERSION"
-sudo docker push $TAG_BASE:$VERSION
-echo "=> $TAG_BASE:latest ($TAG_BASE:${VERSION}_$JENKINS_VERSION)"
-sudo docker tag $TAG_BASE:${VERSION}_$JENKINS_VERSION $TAG_BASE
-sudo docker push $TAG_BASE
-echo "=============== DONE"
+
+if [ "$DRY_RUN"  = "--dry-run" ]
+then
+   exit
+fi
+
+RUN=$(ls -l logs/*.run | wc -l)
+
+while [ $RUN -ne 0 ]
+do
+    printf "%s publish running\e[J\r" $RUN
+    sleep 2
+    RUN=$(ls -l logs/*.run | wc -l)
+done
+echo "DONE"

--- a/releases.lst
+++ b/releases.lst
@@ -1,6 +1,4 @@
 #
-1.642|stable,1.6-stable
-1.658|1.6-latest
-2.7|2.7-latest
-2.23|latest_2.23
-2.50|2.50-latest,latest
+1.642|stable,1.6x-stable
+1.658|1.6x-latest
+2.50|2.x-latest,latest


### PR DESCRIPTION
- Parallel build
- Image push issues
- restrict releases.lst to 3 versions only. 1.6 latest, stable and 2.x latest